### PR TITLE
fix: persist option none is not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ createStore(
      middleWares?: [ log ]; // function to invoke each action
      storageType?: Storage; // session/local storage (default to session)
      
-     // one of 'none' | 'onAction' | 'beforeUnload'
+     // one of 'none' | 'action' | 'beforeUnload'
      // when 'none' is used then state is not persisted
-     // when 'onAction' is used then state is saved to the storage after store action is completed
+     // when 'action' is used then state is saved to the storage after store action is completed
      // when 'beforeUnload' is used then state is saved to storage before page unload and is restored
      // after next page load and then storage is cleared
      persist?: 'onAction' // onAction is default if not provided

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ createStore(
      name?: string; // rename the store
      middleWares?: [ log ]; // function to invoke each action
      storageType?: Storage; // session/local storage (default to session)
+     
+     // one of 'none' | 'onAction' | 'beforeUnload'
+     // when 'none' is used then state is not persisted
+     // when 'onAction' is used then state is saved to the storage after store action is completed
+     // when 'beforeUnload' is used then state is saved to storage before page unload and is restored
+     // after next page load and then storage is cleared
+     persist?: 'onAction' // onAction is default if not provided
   },
 );
 ```

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/react": "^17.0.39",
     "jest": "27.5.0",
-    "microbundle": "^0.14.2",
+    "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
     "react": "^17.0.2",

--- a/src/StateMachineContext.tsx
+++ b/src/StateMachineContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import storeFactory from './logic/storeFactory';
 import { StateMachineContextValue } from './types';
-import { PERSIST_BEFORE_UNLOAD } from './constants';
+import { PersistOption } from './constants';
 
 type PropsChildren = {
   children?: React.ReactNode;
@@ -15,9 +15,9 @@ export const StateMachineProvider: React.FC<PropsChildren> = ({ children }) => {
   const [state, setState] = React.useState(storeFactory.state);
 
   React.useEffect(() => {
-    if (storeFactory.options.persist === PERSIST_BEFORE_UNLOAD) {
+    if (storeFactory.options.persist === PersistOption.BeforeUnload) {
       window.onbeforeunload = () => storeFactory.saveStore();
-      storeFactory.options.storageType.removeItem(storeFactory.options.name);
+      storeFactory.options.storageType?.removeItem(storeFactory.options.name!);
     }
   }, []);
 

--- a/src/StateMachineContext.tsx
+++ b/src/StateMachineContext.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import storeFactory from './logic/storeFactory';
 import { StateMachineContextValue } from './types';
-import { PersistOption } from './constants';
+import { PERSIST_OPTION } from './constants';
 
 type PropsChildren = {
   children?: React.ReactNode;
@@ -15,9 +15,10 @@ export const StateMachineProvider: React.FC<PropsChildren> = ({ children }) => {
   const [state, setState] = React.useState(storeFactory.state);
 
   React.useEffect(() => {
-    if (storeFactory.options.persist === PersistOption.BeforeUnload) {
+    if (storeFactory.options.persist === PERSIST_OPTION.UNLOAD) {
       window.onbeforeunload = () => storeFactory.saveStore();
-      storeFactory.options.storageType?.removeItem(storeFactory.options.name!);
+      storeFactory.options.storageType &&
+        storeFactory.options.storageType.removeItem(storeFactory.options.name!);
     }
   }, []);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,7 @@
 export const STORE_DEFAULT_NAME = '__LSM__';
 export const STORE_ACTION_NAME = '__LSM_NAME__';
-
-export enum PersistOption {
-  None = 'none',
-  OnAction = 'onAction',
-  BeforeUnload = 'beforeUnload',
-}
+export const PERSIST_OPTION = {
+  NONE: 'none',
+  ACTION: 'onAction',
+  UNLOAD: 'beforeUnload',
+} as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,8 @@
 export const STORE_DEFAULT_NAME = '__LSM__';
 export const STORE_ACTION_NAME = '__LSM_NAME__';
-export const PERSIST_BEFORE_UNLOAD = 'beforeUnload';
+
+export enum PersistOption {
+  None = 'none',
+  OnAction = 'onAction',
+  BeforeUnload = 'beforeUnload',
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,6 @@ export const STORE_DEFAULT_NAME = '__LSM__';
 export const STORE_ACTION_NAME = '__LSM_NAME__';
 export const PERSIST_OPTION = {
   NONE: 'none',
-  ACTION: 'onAction',
+  ACTION: 'action',
   UNLOAD: 'beforeUnload',
 } as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 import { StateMachineProvider } from './StateMachineContext';
 import { createStore, useStateMachine } from './stateMachine';
 import { GlobalState } from './types';
+import { PersistOption } from './constants';
 
-export { createStore, StateMachineProvider, useStateMachine, GlobalState };
+export {
+  createStore,
+  StateMachineProvider,
+  useStateMachine,
+  GlobalState,
+  PersistOption,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,5 @@
 import { StateMachineProvider } from './StateMachineContext';
 import { createStore, useStateMachine } from './stateMachine';
 import { GlobalState } from './types';
-import { PersistOption } from './constants';
 
-export {
-  createStore,
-  StateMachineProvider,
-  useStateMachine,
-  GlobalState,
-  PersistOption,
-};
+export { createStore, StateMachineProvider, useStateMachine, GlobalState };

--- a/src/logic/storeFactory.ts
+++ b/src/logic/storeFactory.ts
@@ -1,34 +1,32 @@
-import { STORE_DEFAULT_NAME } from '../constants';
-import { MiddleWare, GlobalState } from '../types';
+import { PersistOption, STORE_DEFAULT_NAME } from '../constants';
+import { MiddleWare, GlobalState, StateMachineOptions } from '../types';
 
 function StoreFactory() {
-  let options = {
+  let options: StateMachineOptions = {
     name: STORE_DEFAULT_NAME,
     middleWares: [] as MiddleWare[],
-    storageType: {} as Storage,
-    persist: '',
+    storageType: undefined,
+    persist: PersistOption.OnAction,
   };
   let state: GlobalState = {};
 
   try {
     options.storageType =
-      typeof sessionStorage !== 'undefined'
-        ? window.sessionStorage
-        : ({} as Storage);
+      typeof sessionStorage !== 'undefined' ? window.sessionStorage : undefined;
   } catch {}
 
   return {
     updateStore(defaultValues: GlobalState) {
       try {
         state =
-          JSON.parse(options.storageType.getItem(options.name) || '') ||
+          JSON.parse(options.storageType?.getItem(options.name!) || '') ||
           defaultValues;
       } catch {
         state = defaultValues;
       }
     },
     saveStore() {
-      options.storageType.setItem(options.name, JSON.stringify(state));
+      options.storageType?.setItem(options.name!, JSON.stringify(state));
     },
     get state() {
       return state;

--- a/src/logic/storeFactory.ts
+++ b/src/logic/storeFactory.ts
@@ -1,12 +1,11 @@
-import { PersistOption, STORE_DEFAULT_NAME } from '../constants';
-import { MiddleWare, GlobalState, StateMachineOptions } from '../types';
+import { PERSIST_OPTION, STORE_DEFAULT_NAME } from '../constants';
+import { GlobalState, StateMachineOptions } from '../types';
 
 function StoreFactory() {
   let options: StateMachineOptions = {
     name: STORE_DEFAULT_NAME,
-    middleWares: [] as MiddleWare[],
-    storageType: undefined,
-    persist: PersistOption.OnAction,
+    middleWares: [],
+    persist: PERSIST_OPTION.ACTION,
   };
   let state: GlobalState = {};
 
@@ -19,14 +18,16 @@ function StoreFactory() {
     updateStore(defaultValues: GlobalState) {
       try {
         state =
-          JSON.parse(options.storageType?.getItem(options.name!) || '') ||
+          (options.storageType &&
+            JSON.parse(options.storageType.getItem(options.name!) || '')) ||
           defaultValues;
       } catch {
         state = defaultValues;
       }
     },
     saveStore() {
-      options.storageType?.setItem(options.name!, JSON.stringify(state));
+      options.storageType &&
+        options.storageType.setItem(options.name!, JSON.stringify(state));
     },
     get state() {
       return state;

--- a/src/stateMachine.tsx
+++ b/src/stateMachine.tsx
@@ -8,7 +8,7 @@ import {
   AnyActions,
   ActionsOutput,
 } from './types';
-import { PERSIST_BEFORE_UNLOAD, STORE_ACTION_NAME } from './constants';
+import { PersistOption, STORE_ACTION_NAME } from './constants';
 
 export function createStore(
   defaultState: GlobalState,
@@ -25,7 +25,9 @@ export function createStore(
     if (typeof window !== 'undefined') {
       window.__LSM_NAME__ = storeFactory.options.name;
       window.__LSM_RESET__ = () =>
-        storeFactory.options.storageType.removeItem(storeFactory.options.name);
+        storeFactory.options.storageType?.removeItem(
+          storeFactory.options.name!,
+        );
     }
   }
 
@@ -53,8 +55,10 @@ const actionTemplate =
     }
 
     (!options || !options.skipRender) && setState(storeFactory.state);
-    storeFactory.options.persist !== PERSIST_BEFORE_UNLOAD &&
+
+    if (storeFactory.options.persist === PersistOption.OnAction) {
       storeFactory.saveStore();
+    }
   };
 
 export function useStateMachine<

--- a/src/stateMachine.tsx
+++ b/src/stateMachine.tsx
@@ -8,7 +8,7 @@ import {
   AnyActions,
   ActionsOutput,
 } from './types';
-import { PersistOption, STORE_ACTION_NAME } from './constants';
+import { PERSIST_OPTION, STORE_ACTION_NAME } from './constants';
 
 export function createStore(
   defaultState: GlobalState,
@@ -25,9 +25,8 @@ export function createStore(
     if (typeof window !== 'undefined') {
       window.__LSM_NAME__ = storeFactory.options.name;
       window.__LSM_RESET__ = () =>
-        storeFactory.options.storageType?.removeItem(
-          storeFactory.options.name!,
-        );
+        storeFactory.options.storageType &&
+        storeFactory.options.storageType.removeItem(storeFactory.options.name!);
     }
   }
 
@@ -56,7 +55,7 @@ const actionTemplate =
 
     (!options || !options.skipRender) && setState(storeFactory.state);
 
-    if (storeFactory.options.persist === PersistOption.OnAction) {
+    if (storeFactory.options.persist === PERSIST_OPTION.ACTION) {
       storeFactory.saveStore();
     }
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { PersistOption } from './constants';
+import { PERSIST_OPTION } from './constants';
 import * as React from 'react';
 
 export interface GlobalState {}
@@ -28,13 +28,11 @@ export type MiddleWare = (
   callbackName: string,
 ) => GlobalState;
 
-export type PersistOptions = `${PersistOption}`;
-
 export type StateMachineOptions = Partial<{
   name: string;
   middleWares: MiddleWare[];
   storageType: Storage;
-  persist: PersistOptions | PersistOption;
+  persist: typeof PERSIST_OPTION[keyof typeof PERSIST_OPTION];
 }>;
 
 declare global {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { PersistOption } from './constants';
 import * as React from 'react';
 
 export interface GlobalState {}
@@ -27,13 +28,13 @@ export type MiddleWare = (
   callbackName: string,
 ) => GlobalState;
 
-export type PersistOptions = 'onAction' | 'none' | 'beforeUnload';
+export type PersistOptions = `${PersistOption}`;
 
 export type StateMachineOptions = Partial<{
   name: string;
   middleWares: MiddleWare[];
   storageType: Storage;
-  persist: PersistOptions;
+  persist: PersistOptions | PersistOption;
 }>;
 
 declare global {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,6 +1888,14 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
+"@rollup/pluginutils@^4.1.2":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
+  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
+  dependencies:
+    estree-walker "^2.0.1"
+    picomatch "^2.2.2"
+
 "@semantic-release/commit-analyzer@^9.0.2":
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz#a78e54f9834193b55f1073fa6258eecc9a545e03"
@@ -2463,10 +2471,10 @@ babel-plugin-polyfill-regenerator@^0.3.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
 
-babel-plugin-transform-async-to-promises@^0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz#13b6d8ef13676b4e3c576d3600b85344bb1ba346"
-  integrity sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==
+babel-plugin-transform-async-to-promises@^0.8.18:
+  version "0.8.18"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.18.tgz#f4dc5980b8afa0fc9c784b8d931afde913413e39"
+  integrity sha512-WpOrF76nUHijnNn10eBGOHZmXQC8JYRME9rOLxStOga7Av2VO53ehVFvVNImMksVtQuL2/7ZNxEgxnx7oo/3Hw==
 
 babel-plugin-transform-replace-expressions@^0.2.0:
   version "0.2.0"
@@ -3298,6 +3306,11 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -3753,7 +3766,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-cache-dir@^3.3.1:
+find-cache-dir@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
   integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
@@ -3805,15 +3818,6 @@ from2@^2.3.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-
-fs-extra@8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
-  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
 
 fs-extra@^10.0.0:
   version "10.0.0"
@@ -4422,6 +4426,11 @@ is-date-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -4577,6 +4586,13 @@ is-weakref@^1.0.1:
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -5165,13 +5181,6 @@ json5@^2.2.0:
   dependencies:
     minimist "^1.2.5"
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -5629,10 +5638,10 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-microbundle@^0.14.2:
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/microbundle/-/microbundle-0.14.2.tgz#2db869c8145bd159aa55058ead47223f58f93bf2"
-  integrity sha512-jODALfU3w7jnJAqw7Tou9uU8e8zH0GRVWzOd/V7eAvD1fsfb9pyMbmzhFZqnX6SCb54eP1EF5oRyNlSxBAxoag==
+microbundle@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/microbundle/-/microbundle-0.15.1.tgz#3fa67128934b31736823b5c868dae4b92d94e766"
+  integrity sha512-aAF+nwFbkSIJGfrJk+HyzmJOq3KFaimH6OIFBU6J2DPjQeg1jXIYlIyEv81Gyisb9moUkudn+wj7zLNYMOv75Q==
   dependencies:
     "@babel/core" "^7.12.10"
     "@babel/plugin-proposal-class-properties" "7.12.1"
@@ -5653,7 +5662,7 @@ microbundle@^0.14.2:
     asyncro "^3.0.0"
     autoprefixer "^10.1.0"
     babel-plugin-macros "^3.0.1"
-    babel-plugin-transform-async-to-promises "^0.8.15"
+    babel-plugin-transform-async-to-promises "^0.8.18"
     babel-plugin-transform-replace-expressions "^0.2.0"
     brotli-size "^4.0.0"
     builtin-modules "^3.1.0"
@@ -5669,7 +5678,8 @@ microbundle@^0.14.2:
     rollup-plugin-bundle-size "^1.0.3"
     rollup-plugin-postcss "^4.0.0"
     rollup-plugin-terser "^7.0.2"
-    rollup-plugin-typescript2 "^0.29.0"
+    rollup-plugin-typescript2 "^0.32.0"
+    rollup-plugin-visualizer "^5.6.0"
     sade "^1.7.4"
     terser "^5.7.0"
     tiny-glob "^0.2.8"
@@ -5875,6 +5885,11 @@ nanoid@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
   integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
+
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -6267,6 +6282,15 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+open@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 opener@^1.5.2:
   version "1.5.2"
@@ -7216,13 +7240,6 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
-    path-parse "^1.0.6"
-
 resolve@^1.10.0, resolve@^1.3.2:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
@@ -7301,16 +7318,26 @@ rollup-plugin-terser@^7.0.2:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup-plugin-typescript2@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.29.0.tgz#b7ad83f5241dbc5bdf1e98d9c3fca005ffe39e1a"
-  integrity sha512-YytahBSZCIjn/elFugEGQR5qTsVhxhUwGZIsA9TmrSsC88qroGo65O5HZP/TTArH2dm0vUmYWhKchhwi2wL9bw==
+rollup-plugin-typescript2@^0.32.0:
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.32.1.tgz#470ded8e1965efac02043cc0ef4a7fa36bed83b9"
+  integrity sha512-RanO8bp1WbeMv0bVlgcbsFNCn+Y3rX7wF97SQLDxf0fMLsg0B/QFF005t4AsGUcDgF3aKJHoqt4JF2xVaABeKw==
   dependencies:
-    "@rollup/pluginutils" "^3.1.0"
-    find-cache-dir "^3.3.1"
-    fs-extra "8.1.0"
-    resolve "1.17.0"
-    tslib "2.0.1"
+    "@rollup/pluginutils" "^4.1.2"
+    find-cache-dir "^3.3.2"
+    fs-extra "^10.0.0"
+    resolve "^1.20.0"
+    tslib "^2.4.0"
+
+rollup-plugin-visualizer@^5.6.0:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.8.1.tgz#deb207017fcf584f3dce088a67eac0d49e4e2a86"
+  integrity sha512-NBT/xN/LWCwDM2/j5vYmjzpEAKHyclo/8Cv8AfTCwgADAG+tLJDy1vzxMw6NO0dSDjmTeRELD9UU3FwknLv0GQ==
+  dependencies:
+    nanoid "^3.3.4"
+    open "^8.4.0"
+    source-map "^0.7.3"
+    yargs "^17.5.1"
 
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
@@ -8089,15 +8116,15 @@ ts-jest@^27.1.3:
     semver "7.x"
     yargs-parser "20.x"
 
-tslib@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
-  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
-
 tslib@^2.0.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -8250,7 +8277,7 @@ universal-user-agent@^6.0.0:
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
-universalify@^0.1.0, universalify@^0.1.2:
+universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
@@ -8486,6 +8513,11 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
+yargs-parser@^21.0.0:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
 yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
@@ -8498,3 +8530,16 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.5.1:
+  version "17.5.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
+  integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"


### PR DESCRIPTION
I have fixed persist options.
Before that, the `'none'` option was not working. Now, when `'none'` option is passed the state is not being saved to any store in action handler.

I have introduced PersistOption enum for better DX but string literals are also available for backward compatibility.
```ts
export enum PersistOption {
  None = 'none',
  OnAction = 'onAction',
  BeforeUnload = 'beforeUnload',
}
```

![CleanShot 2022-09-16 at 14 45 23](https://user-images.githubusercontent.com/20664868/190641866-02d5f1cf-e64f-4bdc-a2fd-5b3af62ff227.png)

I have also updated the store factory options type so it's less hacky.

Locally everything seems to work correctly
